### PR TITLE
Add support for expanded ciphertexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This tool could be used locally or through a docker image.
 Make sure you either have Docker or the Rust toolchain installed on your host machine.
 
 Please replace `ZBC_FHE_TOOL` with either:
- * "`cargo run --features tfhe/aarch64 --release -- `" - for ARM CPUs when running locally on the host
- * "`cargo run --features tfhe/x86_64 --release -- `" - for x86 CPUs when running locally on the host
+ * "`cargo run --features tfhe/aarch64-unix --release -- `" - for ARM CPUs when running locally on the host
+ * "`cargo run --features tfhe/x86_64-unix --release -- `" - for x86 CPUs when running locally on the host
  * "`docker run -v LOCAL_DIR:/zbc-fhe-output ghcr.io/zama-ai/zbc-fhe-tool:TAG zbc-fhe`"
     * replace LOCAL_DIR with a local directory of choice in order to persist output from the tool when using Docker
     * replace TAG with a known tagged version
@@ -25,21 +25,21 @@ ZBC_FHE_TOOL help
 ## Key generation
 
 ```bash
-ZBC_FHE_TOOL generate-keys /path/to/keys/directory
+ZBC_FHE_TOOL generate-keys -d /path/to/keys/directory
 ```
 
 ## Public encryption
 
 ```bash
 # Encryption requires the public key `pks`.
-ZBC_FHE_TOOL public-encrypt-integer32 42 ./ciphertext /path/to/keys/directory/pks
+ZBC_FHE_TOOL public-encrypt-integer32 -c ./ciphertext -p /path/to/keys/directory/pks -v 42
 ```
 
 ## Decryption
 
 ```bash
 # Decryption requires the secret key `cks`.
-ZBC_FHE_TOOL decrypt-integer32 ./ciphertext /path/to/keys/directory/cks
+ZBC_FHE_TOOL decrypt-ciphertext -c ./ciphertext -s /path/to/keys/directory/cks
 ```
 
 # Using published Docker images

--- a/src/ciphertext_types.rs
+++ b/src/ciphertext_types.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use tfhe::{
+    prelude::FheEncrypt, CompactFheUint128List, CompactFheUint16List, CompactFheUint256List,
+    CompactFheUint32List, CompactFheUint64List, CompactFheUint8List, FheUint128, FheUint16,
+    FheUint256, FheUint32, FheUint64, FheUint8,
+};
+
+use crate::gen_keys::gen_keys;
+
+pub enum Precision {
+    FheUint8,
+    FheUint16,
+    FheUint32,
+    FheUint64,
+    FheUint128,
+    FheUint256,
+}
+
+impl Default for Precision {
+    fn default() -> Self {
+        Precision::FheUint8
+    }
+}
+
+pub enum Format {
+    Compact,
+    Expanded,
+}
+
+impl Default for Format {
+    fn default() -> Self {
+        Format::Compact
+    }
+}
+
+#[derive(Default)]
+pub struct CiphertextType {
+    pub precision: Precision,
+    pub format: Format,
+}
+
+// A repository of ciphertext types. Given a ciphertext, the repository returns its type.
+// TODO: Currently, we generate keys and encrypt on new() to determine ciphertext sizes
+// per type. This is inefficient and error-prone.
+pub struct CiphertextTypeRepo {
+    types: HashMap<usize, CiphertextType>,
+}
+
+impl CiphertextTypeRepo {
+    pub fn new() -> CiphertextTypeRepo {
+        let mut repo = CiphertextTypeRepo {
+            types: Default::default(),
+        };
+
+        let (_cks, _, pks) = gen_keys();
+
+        let list = bincode::serialize(&CompactFheUint8List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint8,
+                format: Format::Compact,
+            },
+        );
+
+        let list = bincode::serialize(&CompactFheUint16List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint16,
+                format: Format::Compact,
+            },
+        );
+
+        let list = bincode::serialize(&CompactFheUint32List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint32,
+                format: Format::Compact,
+            },
+        );
+
+        let list = bincode::serialize(&CompactFheUint64List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint64,
+                format: Format::Compact,
+            },
+        );
+
+        let list = bincode::serialize(&CompactFheUint128List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint128,
+                format: Format::Compact,
+            },
+        );
+
+        let list = bincode::serialize(&CompactFheUint256List::encrypt(&vec![0], &pks))
+            .expect("ciphertext serialization");
+        repo.insert(
+            &list,
+            CiphertextType {
+                precision: Precision::FheUint256,
+                format: Format::Compact,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint8::encrypt(0u8, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint8,
+                format: Format::Expanded,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint16::encrypt(0u16, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint16,
+                format: Format::Expanded,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint32::encrypt(0u32, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint32,
+                format: Format::Expanded,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint64::encrypt(0u64, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint64,
+                format: Format::Expanded,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint128::encrypt(0u64, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint128,
+                format: Format::Expanded,
+            },
+        );
+
+        let ct =
+            bincode::serialize(&FheUint256::encrypt(0u64, &pks)).expect("ciphertext serialization");
+        repo.insert(
+            &ct,
+            CiphertextType {
+                precision: Precision::FheUint256,
+                format: Format::Expanded,
+            },
+        );
+        repo
+    }
+
+    pub fn get_type(&self, ciphertext: &[u8]) -> Option<&CiphertextType> {
+        self.types.get(&ciphertext.len())
+    }
+
+    fn insert(&mut self, ct: &[u8], ct_type: CiphertextType) {
+        if self.types.insert(ct.len(), ct_type).is_some() {
+            panic!("type size already existing");
+        }
+    }
+}

--- a/src/gen_keys.rs
+++ b/src/gen_keys.rs
@@ -1,0 +1,13 @@
+use tfhe::{
+    generate_keys, shortint::parameters::PARAM_SMALL_MESSAGE_2_CARRY_2_COMPACT_PK, ClientKey,
+    CompactPublicKey, ConfigBuilder, ServerKey,
+};
+
+pub fn gen_keys() -> (ClientKey, ServerKey, CompactPublicKey) {
+    let config = ConfigBuilder::all_disabled()
+        .enable_custom_integers(PARAM_SMALL_MESSAGE_2_CARRY_2_COMPACT_PK, None)
+        .build();
+    let (cks, sks) = generate_keys(config);
+    let pks = CompactPublicKey::new(&cks);
+    (cks, sks, pks)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod ciphertext_types;
+pub mod gen_keys;


### PR DESCRIPTION
Also, determine the ciphertext type automatically on decryption, based on size. This will be improved in future commits.

Less code duplication will be done using generic functions in a future commit.